### PR TITLE
Add BranchFinder class for finding branching statements in source code

### DIFF
--- a/coveragetool/branchfinder.py
+++ b/coveragetool/branchfinder.py
@@ -1,0 +1,94 @@
+"""A class for finding branch statements in a Python source file.
+
+.. module:: branchfinder
+    :synopsis: A class for finding branch statements in a Python source file.
+
+.. moduleauthor:: Simon Larsén
+"""
+import sys
+import os
+import ast
+import collections
+
+
+def function_identifier(function_name: str, filepath: str) -> str:
+    """Return a unique identifier for a function defined in the file at
+    filepath.
+
+    Args:
+        function_name: Name of the function.
+        filepath: Path to the file where the functino is defined.
+    """
+    return f"{function_name}@{os.path.abspath(filepath)}"
+
+
+class BranchFinder(ast.NodeVisitor):
+    """Traverses the AST of a Python source file and finds all lines containing
+    branch statements `if`, `while` and `for`. One instance of BranchFinder
+    operates on a single Python source file, and is after that useless.
+
+    The visit_<NODE_TYPE> functions are automatically called upon visiting a
+    node of type NODE_TYPE. The conditionals simply add the line number to
+    branches[cur_func], where cur_func is the function currently
+    in scope. visit_FunctionDef is the only exception, it only tracks function
+    scopes for the other visit functions to use.
+
+    Attributes:
+        branches: A defaltdict(set), where the key is a function name and the value
+            a set of all line numbers with conditional statments in that function.
+
+    TODO add support for try/except/else/finally
+    """
+
+    def __init__(self, filepath: str):
+        """
+        Note:
+            All processing on the AST done by the BranchFinder class is
+            performed during initialization.
+
+        Args:
+            filepath: Path to the file to find branches in.
+        """
+        super().__init__()
+        self.branches = collections.defaultdict(set)
+        self._current_function = ""
+        tree = self._parse_file(os.path.abspath(filepath))
+        self.visit(tree)
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        """Visit a FunctionDef node and store the context in
+        self.current_function. This is required to be able to do the mapping of
+        function to line number.
+
+        Restore the context when the FunctionDef is exited.
+
+        Args:
+            node: An function definition.
+        """
+        enclosing_function = self._current_function
+        self._current_function = node.name
+        self.generic_visit(node)
+        self._current_function = enclosing_function
+
+    def visit_If(self, node: ast.If):
+        self._visit_and_register(node)
+
+    def visit_For(self, node: ast.For):
+        self._visit_and_register(node)
+
+    def visit_While(self, node: ast.While):
+        self._visit_and_register(node)
+
+    def _visit_and_register(self, node: ast.Expression):
+        """Register a node in the branches dictionary. Any node with a line
+        number will work, but it should be a conditional node for it to make
+        sense.
+        """
+        self.branches[self._current_function].add(node.lineno)
+        self.generic_visit(node)
+
+    @staticmethod
+    def _parse_file(filepath: str):
+        """Parse the file to an AST."""
+        with open(filepath, mode="r", encoding=sys.getdefaultencoding()) as f:
+            return ast.parse(f.read())

--- a/coveragetool/branchfinder.py
+++ b/coveragetool/branchfinder.py
@@ -11,17 +11,6 @@ import ast
 import collections
 
 
-def function_identifier(function_name: str, filepath: str) -> str:
-    """Return a unique identifier for a function defined in the file at
-    filepath.
-
-    Args:
-        function_name: Name of the function.
-        filepath: Path to the file where the functino is defined.
-    """
-    return f"{function_name}@{os.path.abspath(filepath)}"
-
-
 class BranchFinder(ast.NodeVisitor):
     """Traverses the AST of a Python source file and finds all lines containing
     branch statements `if`, `while` and `for`. One instance of BranchFinder

--- a/tests/coveragetool/sources/loops.py
+++ b/tests/coveragetool/sources/loops.py
@@ -1,0 +1,28 @@
+"""Source file with while loops for testing the coverage tool."""
+
+
+def bounded_looping(n, limit):
+    """Loop at least n times, but at most limit times.
+    Limit takes precedence, and must be positive.
+    """
+    if limit < 0:
+        return
+    elif n > limit:
+        n = limit
+    i = 0
+    while i < n:
+        i += 1
+
+
+def bounded_looping_break(n, limit):
+    """Same as bounded_looping, but with a while-true construct."""
+    if limit < 0:
+        return
+    elif n > limit:
+        n = limit
+    i = 0
+    while True:
+        if i >= n:
+            break
+        else:  # redundant else for fun
+            i += 1

--- a/tests/coveragetool/sources/validator.py
+++ b/tests/coveragetool/sources/validator.py
@@ -1,0 +1,68 @@
+"""Build validator module for pyci_backend.
+
+.. module:: settings
+    :platform: Linux
+    :synopsis: Build validator module for pyci_backend.
+.. moduleauthor:: Martin Nilsson <mnil2@kth.se>
+"""
+import os
+import sys
+import subprocess
+
+
+def validate_python_files(topdirpath: str, verbose: bool = False) -> bool:
+    """Static syntax check of all python modules in the directory tree.
+
+    Recursively iterates through each subdirectory to find modules to check. Checks any
+    file that ends with ".py". By default, only reports failed checks. But if verbose
+    is set to True, this function will report all checks.
+
+    Uses flake8 to find errors in each module. Errors are set so that it tries not to
+    emit false positives and does not consider style.
+
+    Args:
+        topdirpath: The directory.
+        verbose: Whether to report every check, not just failed ones.
+    Returns:
+        Whether all the modules passed the check.
+    Raises:
+        NotADirectoryError if topdirpath is not a directory.
+    """
+    if not os.path.isdir(topdirpath):
+        raise NotADirectoryError(f"{topdirpath} is not a directory")
+
+    def walk_error(oserror: OSError):
+        sys.stderr.write(
+            f'unexpected os error while walking directory tree at "{oserror.filename}"'
+        )
+
+    all_valid = True
+    for dirpath, _, filenames in os.walk(topdirpath, onerror=walk_error):
+        for filename in filenames:
+            if not filename.endswith(".py"):
+                continue
+            filepath = os.path.join(dirpath, filename)
+            if verbose:
+                relative_filepath = os.path.relpath(
+                    filepath, start=os.path.dirname(topdirpath)
+                )
+                print(f'checking module "{relative_filepath}"')
+            if not _validate_python(filepath):
+                all_valid = False
+    return all_valid
+
+
+def _validate_python(filepath: str) -> bool:
+    """Static syntax check of a python module using flake8."""
+    result = subprocess.run(
+        [
+            "flake8",
+            filepath,
+            "--select=F,E999",
+            "--ignore=F401,F402,F403,F404,F405,F406,F632,F811,F812,F841",
+        ],
+        capture_output=True,
+    )
+    print(result.stdout.decode(encoding=sys.getdefaultencoding()))
+    print(result.stderr.decode(encoding=sys.getdefaultencoding()), file=sys.stderr)
+    return result.returncode == 0

--- a/tests/coveragetool/test_branchfinder.py
+++ b/tests/coveragetool/test_branchfinder.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+from coveragetool.branchfinder import BranchFinder
+
+SOURCE_DIR = Path(__file__).parent / Path("sources")
+
+VALIDATOR_PY = SOURCE_DIR / "validator.py"  # "real" source from pyci-backend
+LOOPS_PY = SOURCE_DIR / "loops.py"  # artificial source written just for these tests
+
+
+class TestBranchFinder:
+    """Tests for the BranchFinder class."""
+
+    def test_finds_for_and_if(self):
+        """Test that BranchFinder finds the for and if statements in
+        validator.py.
+        """
+        validate_python_files_branches = {31, 40, 41, 42, 45, 50}
+        _validate_python_branches = {}
+        bf = BranchFinder(VALIDATOR_PY)
+
+        assert not bf.branches["_validate_python"]
+        assert bf.branches["validate_python_files"] == validate_python_files_branches
+
+    def test_finds_while_for_and_if(self):
+        """Test that BranchFinder finds the while, for and if statements in
+        loops.py.
+        """
+        bounded_looping_branches = {8, 10, 13}
+        bounded_looping_break_branches = {19, 21, 24, 25}
+        bf = BranchFinder(LOOPS_PY)
+
+        assert bf.branches["bounded_looping"] == bounded_looping_branches
+        assert bf.branches["bounded_looping_break"] == bounded_looping_break_branches


### PR DESCRIPTION
Adds a class called `BranchFinder` that parses a source file to an abstract syntax tree, and traverses it in order to find lines with branching statements. This will later be used when tracing test execution.

Currently only supports if (which includes elis), for and while. Plans to add try/except support later if there is time, see #16 

Fix #11 