### PR TITLE
Coveragetool pytest plugin

### DIFF
--- a/coveragetool/plugin.py
+++ b/coveragetool/plugin.py
@@ -1,0 +1,77 @@
+"""A local pytest plugin for the coveragetool package.
+
+The plugin is hardcoded to trace the specific files and functions that we are looking at
+in this project. It could be slightly extended to become a general pytest plugin, but
+there is really no call for that here.
+
+.. module:: plugin
+    :synopsis: A local pytest plugin for the coveragetool package.
+
+.. moduleauthor:: Simon Larsén
+"""
+from pathlib import Path
+
+import lektor
+
+from coveragetool.branchfinder import BranchFinder
+from coveragetool.branchtracer import BranchTracer, func_id
+
+
+LEKTOR_DIR = Path(lektor.__file__).parent
+UTILS = LEKTOR_DIR / "utils.py"
+FLOW = LEKTOR_DIR / "types" / "flow.py"
+SOURCESEARCH = LEKTOR_DIR / "sourcesearch.py"
+METAFORMAT = LEKTOR_DIR / "metaformat.py"
+CLI = LEKTOR_DIR / "cli.py"
+FILES = [UTILS, FLOW, SOURCESEARCH, METAFORMAT, CLI]
+
+FUNC_IDS = [
+    func_id(func, filepath)
+    for func, filepath in [
+        ("discover_relevant_flowblock_models", FLOW),
+        ("find_files", SOURCESEARCH),
+        ("decode_flat_data", UTILS),
+        ("prune_file_and_folder", UTILS),
+        ("tokenize", METAFORMAT),
+        ("merge", UTILS),
+        ("get_structure_hash", UTILS),
+        ("_hash", UTILS),
+        ("locate_executable", UTILS),
+        ("plugins_list_cmd", CLI),
+        ("content_file_info_cmd", CLI),
+    ]
+]
+
+
+def _create_tracer(files, func_ids):
+    """Creates a BranchTracer tracing the given files, and filtering the output
+    by the given function ids.
+    """
+    bfs = [BranchFinder(file) for file in files]
+    return BranchTracer.from_branchfinders(*bfs)
+
+
+def create_hook_methods():
+    """Creates and returns the pytest_runtest_call, pytest_runtest_teardown and
+    pytest_sessionfinish hook methods. The reason it is done in a method is to
+    keep side effects from importing this module minimal.
+    """
+
+    tracer = _create_tracer(FILES, FUNC_IDS)
+
+    def pytest_runtest_call(item):
+        """Called before every test to activate tracing."""
+        tracer.start_trace()
+
+    def pytest_runtest_teardown(item):
+        """Called after every test to stop tracing."""
+        tracer.stop_trace()
+
+    def pytest_sessionfinish(session, exitstatus):
+        """Prints out the results after the pytest session is done."""
+        from pprint import pprint
+
+        print()
+        pprint(tracer.function_coverage(*FUNC_IDS))
+
+    return pytest_runtest_call, pytest_runtest_teardown, pytest_sessionfinish

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,21 @@
+# Running with the coveragetool plugin
+To run the test suite with our homebrewn coveragetool, you need to set the
+`COVTOOL_TRACE` environment variable to anything but the empty string.
+If you have a look at the top of [`conftest.py`](conftest.py), you'll see why
+this works. You should also ignore the tests in `tests/coveragetool`, as they
+could interfere with the tracing (they shouldn't but they use the same global
+tracing mechanics, so ignore just to be safe). This one-liner takes care of
+everything:
+
+```bash
+$ export COVTOOL_TRACE=1; pytest tests/ --ignore=tests/coveragetool; unset COVTOOL_TRACE;
+```
+
+The files that are traced and functions that are displayed are hardcoded in
+[`coveragetool/plugin.py`](../coveragetool/plugin.py). Note that the tool
+currently only traces `if`, `while` and `for` statements. It also gets
+really confused by conditions spread across multiple lines, so for maximum
+non-confusion, edit any traced functions to have only single-line conditions.
+
+You may need to install the project in editable mode again, so if this isn't
+working, run `pip install -e .[test]` from the project root.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,22 +2,32 @@ import os
 import shutil
 import subprocess
 import textwrap
+
 import pytest
 
 from lektor.utils import is_windows
 
+# coveragetool plugin
+if os.getenv("COVTOOL_TRACE"):
+    from coveragetool.plugin import create_hook_methods
 
-@pytest.fixture(scope='function')
+    pytest_runtest_call, pytest_runtest_teardown, pytest_sessionfinish = (
+        create_hook_methods()
+    )
+
+
+@pytest.fixture(scope="function")
 def project():
     from lektor.project import Project
-    return Project.from_path(os.path.join(os.path.dirname(__file__),
-                                          'demo-project'))
+
+    return Project.from_path(os.path.join(os.path.dirname(__file__), "demo-project"))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def scratch_project(tmpdir):
     base = tmpdir.mkdir("scratch-proj")
-    lektorfile_text = textwrap.dedent(u"""
+    lektorfile_text = textwrap.dedent(
+        u"""
         [project]
         name = Scratch
 
@@ -25,22 +35,28 @@ def scratch_project(tmpdir):
         primary = yes
         [alternatives.de]
         url_prefix = /de/
-    """)
+    """
+    )
     base.join("Scratch.lektorproject").write_text(lektorfile_text, "utf8", ensure=True)
-    content_text = textwrap.dedent(u"""
+    content_text = textwrap.dedent(
+        u"""
         _model: page
         ---
         title: Index
         ---
         body: Hello World!
-    """)
+    """
+    )
     base.join("content", "contents.lr").write_text(content_text, "utf8", ensure=True)
-    template_text = textwrap.dedent(u"""
+    template_text = textwrap.dedent(
+        u"""
         <h1>{{ this.title }}</h1>
         {{ this.body }}
-    """)
+    """
+    )
     base.join("templates", "page.html").write_text(template_text, "utf8", ensure=True)
-    model_text = textwrap.dedent(u"""
+    model_text = textwrap.dedent(
+        u"""
         [model]
         label = {{ this.title }}
 
@@ -48,140 +64,165 @@ def scratch_project(tmpdir):
         type = string
         [fields.body]
         type = markdown
-    """)
+    """
+    )
     base.join("models", "page.ini").write_text(model_text, "utf8", ensure=True)
 
     from lektor.project import Project
+
     return Project.from_path(str(base))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def env(project):
     from lektor.environment import Environment
+
     return Environment(project)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def scratch_env(scratch_project):
     from lektor.environment import Environment
+
     return Environment(scratch_project)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def pad(env):
     from lektor.db import Database
+
     return Database(env).new_pad()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def scratch_pad(scratch_env):
     from lektor.db import Database
+
     return Database(scratch_env).new_pad()
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def scratch_tree(scratch_pad):
     from lektor.db import Tree
+
     return Tree(scratch_pad)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def builder(tmpdir, pad):
     from lektor.builder import Builder
+
     return Builder(pad, str(tmpdir.mkdir("output")))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def scratch_builder(tmpdir, scratch_pad):
     from lektor.builder import Builder
+
     return Builder(scratch_pad, str(tmpdir.mkdir("output")))
 
 
 # Builder for child-sources-test-project, a project to test that child sources
 # are built even if they're filtered out by a pagination query.
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def child_sources_test_project_builder(tmpdir):
     from lektor.db import Database
     from lektor.environment import Environment
     from lektor.project import Project
     from lektor.builder import Builder
 
-    project = Project.from_path(os.path.join(os.path.dirname(__file__),
-                                             'child-sources-test-project'))
+    project = Project.from_path(
+        os.path.join(os.path.dirname(__file__), "child-sources-test-project")
+    )
     env = Environment(project)
     pad = Database(env).new_pad()
 
     return Builder(pad, str(tmpdir.mkdir("output")))
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def F():
     from lektor.db import F
+
     return F
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def eval_expr(env):
     from lektor.environment import Expression
+
     def eval_expr(expr, **kwargs):
         expr = Expression(env, expr)
         return expr.evaluate(**kwargs)
+
     return eval_expr
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def reporter(request, env):
     from lektor.reporter import BufferReporter
+
     reporter = BufferReporter(env)
     reporter.push()
     request.addfinalizer(reporter.pop)
     return reporter
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def os_user(monkeypatch):
-    if os.name == 'nt':
+    if os.name == "nt":
         import getpass  # pylint: disable=unused-import
-        monkeypatch.setattr('getpass.getuser', lambda: 'Lektor Test')
+
+        monkeypatch.setattr("getpass.getuser", lambda: "Lektor Test")
         return "lektortest"
 
     # we disable pylint, because there is no such
     # modules on windows & it's false positive
     import pwd  # pylint: disable=import-error
-    struct = pwd.struct_passwd((
-        'lektortest',  # pw_name
-        'lektorpass',  # pw_passwd
-        9999,  # pw_uid
-        9999,  # pw_gid
-        'Lektor Test',  # pw_gecos
-        '/tmp/lektortest',  # pw_dir
-        '/bin/lektortest',  # pw_shell
-    ))
+
+    struct = pwd.struct_passwd(
+        (
+            "lektortest",  # pw_name
+            "lektorpass",  # pw_passwd
+            9999,  # pw_uid
+            9999,  # pw_gid
+            "Lektor Test",  # pw_gecos
+            "/tmp/lektortest",  # pw_dir
+            "/bin/lektortest",  # pw_shell
+        )
+    )
     monkeypatch.setattr("pwd.getpwuid", lambda id: struct)
     monkeypatch.setenv("USER", "lektortest")
     return "lektortest"
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def git_user_email(request):
-    old_email = subprocess.Popen(['git', 'config', 'user.email'],
-                                 stdout=subprocess.PIPE,
-                                 stderr=subprocess.PIPE).communicate()[0].strip()
+    old_email = (
+        subprocess.Popen(
+            ["git", "config", "user.email"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        .communicate()[0]
+        .strip()
+    )
     # on windows subprocess need str in input
     # but returns bytes on exit
     if is_windows:
-        old_email = old_email.decode('utf-8')
+        old_email = old_email.decode("utf-8")
 
     def cleanup():
-        subprocess.check_call(['git', 'config', 'user.email', old_email])
+        subprocess.check_call(["git", "config", "user.email", old_email])
+
     request.addfinalizer(cleanup)
 
     email = "lektortest@example.com"
-    subprocess.check_call(['git', 'config', 'user.email', email])
+    subprocess.check_call(["git", "config", "user.email", email])
     return email
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def project_cli_runner(isolated_cli_runner, project):
     """
     Copy the project files into the isolated file system used by the

--- a/tests/coveragetool/test_plugin.py
+++ b/tests/coveragetool/test_plugin.py
@@ -1,0 +1,19 @@
+from unittest.mock import patch, MagicMock
+from coveragetool import plugin
+
+
+def test_create_hook_methods():
+    """Happy path test of create_hook_methods asserting that the hook methods are
+    callable and the _create_tracer method is called once with the correct args.
+    """
+    with patch(
+        "coveragetool.plugin._create_tracer", autospec=True, callable=MagicMock
+    ) as mock_create_tracer:
+        pytest_runtest_call, pytest_runtest_teardown, pytest_sessionfinish = (
+            plugin.create_hook_methods()
+        )
+
+    assert callable(pytest_runtest_call)
+    assert callable(pytest_runtest_teardown)
+    assert callable(pytest_sessionfinish)
+    mock_create_tracer.assert_called_once_with(plugin.FILES, plugin.FUNC_IDS)


### PR DESCRIPTION
Adds a pytest plugin for the coverage tool. See `tests/README.md` for usage details.

Sorry about the bad diff in `conftest.py`, the _real_ non-blacn-induced diff is lines 10-17. It's just the activation of the plugin by importing the hook methods.

Fix #48 