### PR TITLE
Refactor db.coerce

### DIFF
--- a/tests/newtests/test_cli_new.py
+++ b/tests/newtests/test_cli_new.py
@@ -16,7 +16,21 @@ def contents_file(project_root):
 class TestContentFileInfoCmd:
     """Tests for lektor.cli.content_file_info_cmd.
 
-    This function was untested in the initial test suite.
+    The function takes a bunch of filepaths and prints out some Lektor-related info
+    about them. A pre-condition is that all files are from the same Lektor-project.
+
+    This function was entirely untested in the initial test suite.
+
+    Previously untested requirements:
+
+    * Print error and exit if files are frome different projects.
+    * Print error and exit if no files are provided.
+    * Print error and exit if any of the files is not related to a Lektor project.
+    * Print error and exit if none of the files are content files.
+    * Print information about each content file.
+    * All of the above requirements, but with output as JSON.
+
+    Requirements tested by this suite is specified in each of the test methods.
     """
 
     CMD = "content-file-info"

--- a/tests/newtests/test_db_new.py
+++ b/tests/newtests/test_db_new.py
@@ -1,0 +1,45 @@
+from lektor import db
+
+
+class TestCompHelperCoerce:
+    """Previously tested requirements of coerce:
+        - If the arguments are of the same type, return the input
+        - If the first argument is Undefined, change it to None in the output
+        - If the second argument is Undefined, change it to None in the output
+        - If both arguments are strings, normalize them both in the output
+    Previously untested but now tested requirements:
+        - Given a number and a number-convertible arg s, convert s to a number in the output
+        - Given a number-convertible arg s and then a number, convert s to a number in the output
+        - Given a non-number-convertible arg and then a number, return the input
+        - Given a number and then a non-number-convertible arg, return the input
+    Untested requirements:
+        - None
+    """
+
+    def test_number_and_then_convertible(self):
+        """If the first arg is a number, and the second can be converted to a number, the second is
+        converted
+        """
+        number = 1
+        assert db._CmpHelper.coerce(1, str(number)) == (number, number)
+
+    def test_convertible_and_then_number(self):
+        """If the second arg is a number, and the first is not a number but can be converted to a
+        number, the first is converted
+        """
+        number = 1
+        assert db._CmpHelper.coerce(str(number), 1) == (number, number)
+
+    def test_first_number_but_not_second(self):
+        """If the first arg is a number, but the second can't be converted to a number, return the
+        input
+        """
+        a, b = 1, []
+        assert db._CmpHelper.coerce(1, []) == (a, b)
+
+    def test_second_number_but_not_first(self):
+        """If the second arg is a number, but the first can't be converted to a number, return the
+        input
+        """
+        a, b = [], 1
+        assert db._CmpHelper.coerce([], 1) == (a, b)


### PR DESCRIPTION
Adds implemented refactoring of the `db.coerce` method. The original function had CC = 14. The new functions have the following CC's:

| Method                  | CC |
|-------------------------|----|
| db.coerce               | 6  |
| db._undefined           | 3  |
| db._numeric             | 3  |
| db._is_numeric_instance | 2  |
| db._error               | 2  |

Fix #97 